### PR TITLE
Add Plaid integrations

### DIFF
--- a/lib/plaid/item.ex
+++ b/lib/plaid/item.ex
@@ -171,7 +171,7 @@ defmodule Plaid.Item do
   end
 
   @doc """
-  [Creates a processor token](https://developers.dwolla.com/resources/dwolla-plaid-integration.html)
+  [Creates a Dwolla token](https://developers.dwolla.com/resources/dwolla-plaid-integration.html)
   used to create an authenticated funding source with Dwolla.
 
   Parameters
@@ -184,10 +184,33 @@ defmodule Plaid.Item do
   {:ok, %{processor_token: "some-token", request_id: "k522f2"}}
   ```
   """
-  @spec create_processor_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
-  def create_processor_token(params, config \\ %{}) do
+  @spec create_dwolla_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def create_dwolla_token(params, config \\ %{}) do
     config = validate_cred(config)
     endpoint = "processor/dwolla/processor_token/create"
+
+    make_request_with_cred(:post, endpoint, config, params)
+    |> Utils.handle_resp(@endpoint)
+  end
+
+  @doc """
+  [Creates a Stripe token](https://stripe.com/docs/ach)
+  used to create an authenticated funding source with Stripe.
+
+  Parameters
+  ```
+  %{access_token: "access-env-identifier", account_id: "plaid-account-id"}
+  ```
+
+  Response
+  ```
+  {:ok, %{stripe_bank_account_token: "some-token", request_id: "k522f2"}}
+  ```
+  """
+  @spec create_stripe_token(params, config | nil) :: {:ok, map} | {:error, Plaid.Error.t()}
+  def create_stripe_token(params, config \\ %{}) do
+    config = validate_cred(config)
+    endpoint = "processor/stripe/bank_account_token/create"
 
     make_request_with_cred(:post, endpoint, config, params)
     |> Utils.handle_resp(@endpoint)

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -126,42 +126,32 @@ defmodule Plaid.Utils do
 
   def map_response(%{"new_access_token" => _} = response, :item) do
     response
-    |> Map.take(["new_access_token", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
+    |> atomify_response(["new_access_token", "request_id"])
   end
 
   def map_response(%{"access_token" => _} = response, :item) do
     response
-    |> Map.take(["access_token", "item_id", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
+    |> atomify_response(["access_token", "item_id", "request_id"])
   end
 
   def map_response(%{"public_token" => _} = response, :item) do
     response
-    |> Map.take(["public_token", "expiration", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
+    |> atomify_response(["public_token", "expiration", "request_id"])
   end
 
   def map_response(%{"deleted" => _} = response, :item) do
     response
-    |> Map.take(["deleted", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
+    |> atomify_response(["deleted", "request_id"])
   end
 
   def map_response(%{"processor_token" => _} = response, :item) do
     response
-    |> Map.take(["processor_token", "request_id"])
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      Map.put(acc, String.to_atom(k), v)
-    end)
+    |> atomify_response(["processor_token", "request_id"])
+  end
+
+  def map_response(%{"stripe_bank_account_token" => _} = response, :item) do
+    response
+    |> atomify_response(["stripe_bank_account_token", "request_id"])
   end
 
   def map_response(response, :"investments/holdings") do
@@ -192,5 +182,13 @@ defmodule Plaid.Utils do
         item: %Plaid.Item{}
       }
     )
+  end
+
+  defp atomify_response(response, args) do
+    response
+    |> Map.take(args)
+    |> Enum.reduce(%{}, fn {k, v}, acc ->
+      Map.put(acc, String.to_atom(k), v)
+    end)
   end
 end

--- a/lib/plaid/utils.ex
+++ b/lib/plaid/utils.ex
@@ -124,35 +124,23 @@ defmodule Plaid.Utils do
     Poison.Decode.decode(new_response, as: %Plaid.Item{})
   end
 
-  def map_response(%{"new_access_token" => _} = response, :item) do
-    response
-    |> atomify_response(["new_access_token", "request_id"])
-  end
+  def map_response(%{"new_access_token" => _} = response, :item),
+    do: atomify_response(response, ["new_access_token", "request_id"])
 
-  def map_response(%{"access_token" => _} = response, :item) do
-    response
-    |> atomify_response(["access_token", "item_id", "request_id"])
-  end
+  def map_response(%{"access_token" => _} = response, :item),
+    do: atomify_response(response, ["access_token", "item_id", "request_id"])
 
-  def map_response(%{"public_token" => _} = response, :item) do
-    response
-    |> atomify_response(["public_token", "expiration", "request_id"])
-  end
+  def map_response(%{"public_token" => _} = response, :item),
+    do: atomify_response(response, ["public_token", "expiration", "request_id"])
 
-  def map_response(%{"deleted" => _} = response, :item) do
-    response
-    |> atomify_response(["deleted", "request_id"])
-  end
+  def map_response(%{"deleted" => _} = response, :item),
+    do: atomify_response(response, ["deleted", "request_id"])
 
-  def map_response(%{"processor_token" => _} = response, :item) do
-    response
-    |> atomify_response(["processor_token", "request_id"])
-  end
+  def map_response(%{"processor_token" => _} = response, :item),
+    do: atomify_response(response, ["processor_token", "request_id"])
 
-  def map_response(%{"stripe_bank_account_token" => _} = response, :item) do
-    response
-    |> atomify_response(["stripe_bank_account_token", "request_id"])
-  end
+  def map_response(%{"stripe_bank_account_token" => _} = response, :item),
+    do: atomify_response(response, ["stripe_bank_account_token", "request_id"])
 
   def map_response(response, :"investments/holdings") do
     Poison.Decode.decode(response,

--- a/test/lib/plaid/item_test.exs
+++ b/test/lib/plaid/item_test.exs
@@ -114,7 +114,7 @@ defmodule Plaid.ItemTest do
       assert resp.deleted == body["deleted"]
     end
 
-    test "create_processor_token/1 request POST and returns token", %{bypass: bypass} do
+    test "create_dwolla_token/1 request POST and returns token", %{bypass: bypass} do
       body = http_response_body(:processor_token)
 
       Bypass.expect(bypass, fn conn ->
@@ -124,7 +124,22 @@ defmodule Plaid.ItemTest do
       end)
 
       assert {:ok, resp} =
-               Plaid.Item.create_processor_token(%{access_token: "token", account_id: "id"})
+               Plaid.Item.create_dwolla_token(%{access_token: "token", account_id: "id"})
+
+      assert resp.processor_token
+    end
+
+    test "create_stripe_token/1 request POST and returns token", %{bypass: bypass} do
+      body = http_response_body(:processor_token)
+
+      Bypass.expect(bypass, fn conn ->
+        assert "POST" == conn.method
+        assert "processor/stripe/bank_account_token/create" == Enum.join(conn.path_info, "/")
+        Plug.Conn.resp(conn, 200, Poison.encode!(body))
+      end)
+
+      assert {:ok, resp} =
+               Plaid.Item.create_stripe_token(%{access_token: "token", account_id: "id"})
 
       assert resp.processor_token
     end


### PR DESCRIPTION
## Motivation

The plaid-elixir library only had the Dwolla integration, which was the default processor being called by `create_processor_token`. 

The Stripe integration is also offered by Plaid, so plaid-elixir should support it too.

## Changes

- Obsoleted the `create_processor_token` function because there is no default processor;
- Added `create_dwolla_token/3`;
- Added `create_stripe_token/3`;
- Handle Stripe response and refactor `map_responses`.